### PR TITLE
Python Versionsmatrix und Tox

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -3,14 +3,16 @@ name: "CI"
 on:
   workflow_call:
     inputs:
-      packages:
+      pytest-python-versions:
+        # GitHub workflow inputs do not support lists, so we expect a JSON string.
         type: string
         required: true
-        description: Space-seperated list of source packages, not including tests, which are always assumed to be in
-          'tests'.
 
 jobs:
   pytest:
+    strategy:
+      matrix:
+        python-version: ${{ fromJSON(inputs.pytest-python-versions) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -20,7 +22,7 @@ jobs:
           poetry config -n virtualenvs.in-project true
       - uses: actions/setup-python@v4
         with:
-          python-version-file: '.python-version'
+          python-version: ${{ matrix.python-version }}
           cache: poetry
       - name: Install dependencies
         run: poetry install -n
@@ -35,7 +37,8 @@ jobs:
 
       - name: Run pytest
         run: |
-          coverage run -m pytest --md pytest-report.md
+          # We tell tox to run envs with the factor "pytest", tox-gh-actions narrows down the python version for us.
+          tox -f pytest -- --md pytest-report.md
           coverage xml
           coverage html -d ./html_report --title=${{steps.commit.outputs.short}}
 
@@ -86,7 +89,7 @@ jobs:
           poetry config -n virtualenvs.in-project true
       - uses: actions/setup-python@v4
         with:
-          python-version-file: '.python-version'
+          python-version: ${{ fromJSON(inputs.pytest-python-versions)[0] }}
           cache: poetry
       - name: Install dependencies
         run: poetry install -n
@@ -96,7 +99,7 @@ jobs:
           echo "$PWD/.venv/bin" >> $GITHUB_PATH
 
       - name: Run pylint
-        run: pylint ${{ inputs.packages }} tests
+        run: tox -f pylint
 
   mypy:
     runs-on: ubuntu-latest
@@ -108,7 +111,7 @@ jobs:
           poetry config -n virtualenvs.in-project true
       - uses: actions/setup-python@v4
         with:
-          python-version-file: '.python-version'
+          python-version: ${{ fromJSON(inputs.pytest-python-versions)[0] }}
           cache: poetry
       - name: Install dependencies
         run: poetry install -n
@@ -118,7 +121,7 @@ jobs:
           echo "$PWD/.venv/bin" >> $GITHUB_PATH
 
       - name: Run mypy
-        run: mypy ${{ inputs.packages }} tests
+        run: tox -f mypy
 
   flake8:
     runs-on: ubuntu-latest
@@ -130,7 +133,7 @@ jobs:
           poetry config -n virtualenvs.in-project true
       - uses: actions/setup-python@v4
         with:
-          python-version-file: '.python-version'
+          python-version: ${{ fromJSON(inputs.pytest-python-versions)[0] }}
           cache: poetry
       - name: Install dependencies
         run: poetry install -n
@@ -140,7 +143,7 @@ jobs:
           echo "$PWD/.venv/bin" >> $GITHUB_PATH
 
       - name: Run flake8
-        run: flake8 ${{ inputs.packages }} tests
+        run: tox -f flake8
 
   build:
     runs-on: ubuntu-latest
@@ -152,7 +155,7 @@ jobs:
           poetry config -n virtualenvs.in-project true
       - uses: actions/setup-python@v4
         with:
-          python-version-file: '.python-version'
+          python-version: ${{ fromJSON(inputs.pytest-python-versions)[0] }}
           cache: poetry
       - name: Install dependencies
         run: poetry install -n

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -62,17 +62,6 @@ jobs:
         if: always()
         run: cat pytest-report.md > "$GITHUB_STEP_SUMMARY"
 
-      - uses: jwalton/gh-find-current-pr@v1
-        if: always()
-        id: find_pr
-
-      - name: Comment on open PR
-        uses: marocchino/sticky-pull-request-comment@v2
-        if: always() && steps.find_pr.outputs.number
-        with:
-          number: ${{ steps.find_pr.outputs.number }}
-          path: pytest-report.md
-
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Leider unterstützt GitHub Actions keinen nativen List-Typen in Workflow Inputs, deshalb werden die gewünschten Versionen als JSON-Liste in den Workflow gegeben :(

Nur der pytest-Job läuft in einer Matrix. Ich bin mir selbst nicht sicher, ob es sinnvoll ist, das auch für die pylint-, flake8- und mypy-Jobs zu machen, aber Menschen im Internet scheinen es nicht zu tun, deshalb habe ich das so übernommen. Die Jobs benutzen einfach die erste gegebene Python-Version.

Im Falle des pytest-Jobs wird in der Kommandozeile lediglich der _Faktor_ `pytest` ausgewählt. Das würde `py39-pytest`, `py310-pytest`, `pytest-egalwas` auswählen. tox-gh-actions filtert dann automatisch auf die korrekte Python-Version runter.

Der neuste Commit trägt den Tag v5.