### PR TITLE
Kein Tox in CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -7,29 +7,36 @@ on:
         # GitHub workflow inputs do not support lists, so we expect a JSON string.
         type: string
         required: true
+      packages:
+        type: string
+        description: Space-separated list of packages, including tests.
+
+env:
+  POETRY_VIRTUALENVS_IN_PROJECT: true
 
 jobs:
   pytest:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ${{ fromJSON(inputs.pytest-python-versions) }}
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install poetry
-        run: |
-          pipx install "poetry>=1.1.14,<2.0.0"
-          poetry config -n virtualenvs.in-project true
+      - # setup-python's poetry caching requires poetry to be installed, so we install it before python.
+        name: Install poetry
+        run: pip install "poetry>=1.1.14,<2.0.0"
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: poetry
+
       - name: Install dependencies
         run: poetry install -n
       - name: Activate virtualenv
         run: |
           echo "VIRTUAL_ENV=$PWD/.venv" >> $GITHUB_ENV
           echo "$PWD/.venv/bin" >> $GITHUB_PATH
+      - run: python --version
 
       - name: Get commit
         uses: pr-mpt/actions-commit-hash@v2
@@ -37,10 +44,9 @@ jobs:
 
       - name: Run pytest
         run: |
-          # We tell tox to run envs with the factor "pytest", tox-gh-actions narrows down the python version for us.
-          tox -f pytest -- --md pytest-report.md
+          coverage run -m pytest --md pytest-report.md
           coverage xml
-          coverage html -d ./html_report --title=${{steps.commit.outputs.short}}
+          coverage html -d ./html_report --title='${{ steps.commit.outputs.short }}'
 
       - name: Generate coverage report
         uses: irongut/CodeCoverageSummary@v1.3.0
@@ -72,86 +78,83 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install poetry
-        run: |
-          pipx install "poetry>=1.1.14,<2.0.0"
-          poetry config -n virtualenvs.in-project true
+      - # setup-python's poetry caching requires poetry to be installed, so we install it before python.
+        name: Install poetry
+        run: pip install "poetry>=1.1.14,<2.0.0"
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ fromJSON(inputs.pytest-python-versions)[0] }}
           cache: poetry
+
       - name: Install dependencies
         run: poetry install -n
       - name: Activate virtualenv
         run: |
           echo "VIRTUAL_ENV=$PWD/.venv" >> $GITHUB_ENV
           echo "$PWD/.venv/bin" >> $GITHUB_PATH
+      - run: python --version
 
       - name: Run pylint
-        run: tox -f pylint
+        run: pylint ${{ inputs.packages }}
 
   mypy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install poetry
-        run: |
-          pipx install "poetry>=1.1.14,<2.0.0"
-          poetry config -n virtualenvs.in-project true
+        run: pip install "poetry>=1.1.14,<2.0.0"
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ fromJSON(inputs.pytest-python-versions)[0] }}
           cache: poetry
+
       - name: Install dependencies
         run: poetry install -n
       - name: Activate virtualenv
         run: |
           echo "VIRTUAL_ENV=$PWD/.venv" >> $GITHUB_ENV
           echo "$PWD/.venv/bin" >> $GITHUB_PATH
+      - run: python --version
 
       - name: Run mypy
-        run: tox -f mypy
+        run: mypy ${{ inputs.packages }}
 
   flake8:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install poetry
-        run: |
-          pipx install "poetry>=1.1.14,<2.0.0"
-          poetry config -n virtualenvs.in-project true
+        run: pip install "poetry>=1.1.14,<2.0.0"
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ fromJSON(inputs.pytest-python-versions)[0] }}
           cache: poetry
+
       - name: Install dependencies
         run: poetry install -n
       - name: Activate virtualenv
         run: |
           echo "VIRTUAL_ENV=$PWD/.venv" >> $GITHUB_ENV
           echo "$PWD/.venv/bin" >> $GITHUB_PATH
+      - run: python --version
 
       - name: Run flake8
-        run: tox -f flake8
+        run: flake8 ${{ inputs.packages }}
 
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install poetry
-        run: |
-          pipx install "poetry>=1.1.14,<2.0.0"
-          poetry config -n virtualenvs.in-project true
+        run: pip install "poetry>=1.1.14,<2.0.0"
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ fromJSON(inputs.pytest-python-versions)[0] }}
           cache: poetry
+
       - name: Install dependencies
         run: poetry install -n
-      - name: Activate virtualenv
-        run: |
-          echo "VIRTUAL_ENV=$PWD/.venv" >> $GITHUB_ENV
-          echo "$PWD/.venv/bin" >> $GITHUB_PATH
+      - run: python --version
 
       - name: Build
         run: poetry build -n


### PR DESCRIPTION
Wie auf Matrix erwähnt:
> Ich habe mich gerade noch etwas mit tox, GitHub Actions und deren Zusammenspiel befasst. Ich finde tox zwar für's lokale entwickeln super (und will auch eigentlich nicht darauf verzichten), in unserem Workflow bringt es aber keinen wirklichen Mehrwert, da die Verwaltung der verschiedenen Python-Versionen durch GitHub Actions passiert und das nunmal das Kernfeature von tox ist. Eine Möglichkeit, tox ohne Einbußen in Laufzeit und Übersichtlichkeit im Workflow zu verwenden, habe ich nicht gefunden.
> 
> Ich würde deshalb Vorschlagen, tox wieder aus dem Workflow zu entfernen und dort stattdessen die Befehle direkt aufzurufen. Das sollte, wie von Martin angebracht, die Logs wieder etwas ordentlicher machen und auch ein paar Sekunden Laufzeit sparen. Die Tox-Konfiguration bleibt bestehen und kann lokal genutzt werden. tox-gh-actions kommt natürlich weg.

Die Pakete werden jetzt also wieder per Input in den Workflow gegeben.

Nebenbei 2 kleine Änderungen:
* Umgebungsvariable `POETRY_VIRTUALENVS_IN_PROJECT` statt in jedem Job `poetry config -n virtualenvs.in-project true` aufzurufen
* Installation von Poetry mit pip statt mit pipx. Da der Runner mit einer sauberen Python-Installation daherkommt und wir global nur Poetry installieren, halte ich Konflikte da für sehr unwahrscheinlich, und das spart ein paar Sekunden.

Der neuste Commit trägt den Tag v6.